### PR TITLE
Feat/50

### DIFF
--- a/web/app/Explorer.js
+++ b/web/app/Explorer.js
@@ -565,9 +565,15 @@ bluewave.Explorer = function(parent, config) {
             node.ondblclick();
         });
         drawflow.on('nodeRemoved', function(nodeID) {
+            removeInputs(nodes, nodeID);
             delete nodes[nodeID+""];
         });
-
+        drawflow.on('connectionRemoved', function(info) {
+            var outputID = info.output_id+"";
+            var inputID = info.input_id+"";
+            var node = nodes[inputID];
+            delete node.inputs[outputID+""];
+        });
 
 
       //Create menubar
@@ -1119,6 +1125,22 @@ bluewave.Explorer = function(parent, config) {
         sankeyEditor.show();
     };
 
+  //**************************************************************************
+  //** removeInputs
+  //**************************************************************************
+    var removeInputs = function(nodes, nodeID){
+        for(var key in nodes){
+            if (nodes.hasOwnProperty(key)){
+                var node = nodes[key];
+                for(var inputID in node.inputs){
+                    if(inputID === nodeID){
+                        delete node.inputs[nodeID+""];
+                        console.log("removed");
+                    }
+                }
+            }
+        }
+    }
 
   //**************************************************************************
   //** editLayout

--- a/web/app/Explorer.js
+++ b/web/app/Explorer.js
@@ -1135,7 +1135,6 @@ bluewave.Explorer = function(parent, config) {
                 for(var inputID in node.inputs){
                     if(inputID === nodeID){
                         delete node.inputs[nodeID+""];
-                        console.log("removed");
                     }
                 }
             }
@@ -1623,6 +1622,19 @@ bluewave.Explorer = function(parent, config) {
         nameEditor.show();
     };
 
+  //**************************************************************************
+  //** checkConnection
+  //**************************************************************************
+    var checkConnection = function(layoutNode, node){
+        var connected = false;
+        for(var inputID in layoutNode.inputs){
+            tempNode = nodes[inputID];
+            if(tempNode === node){
+                connected = true;
+            }
+        }
+        return connected;
+    }
 
   //**************************************************************************
   //** updateDashboard
@@ -1655,6 +1667,8 @@ bluewave.Explorer = function(parent, config) {
             if (layoutNode.config.hasOwnProperty(key)){
                 var rect = layoutNode.config[key];
                 var node = nodes[key];
+                var connected = checkConnection(layoutNode, node);
+                if (!connected) continue;
                 if (!node) continue;
                 var chartConfig = node.config;
                 if (!chartConfig) chartConfig = {};


### PR DESCRIPTION
When using the layout node in the Canvas, if you removed a different node from the canvas that was attached to the layout node, previously it wouldn't register it as missing until you clicked on the layout node itself. Now immediately that node is removed when you go to the preview window. Same thing happens when you remove a linkage between a layout node and another node as well.